### PR TITLE
Fix a bug when evaluating link relations.

### DIFF
--- a/earl/src/main/java/com/einmalfel/earl/AtomEntry.java
+++ b/earl/src/main/java/com/einmalfel/earl/AtomEntry.java
@@ -155,23 +155,23 @@ public class AtomEntry extends AtomCommonAttributes implements Item {
       return null;
     }
     for (AtomLink link : links)
-      if (link.type != null && "alternate".equals(link.type)) {
+      if ("alternate".equals(link.rel)) {
         return link.href.toString();
       }
     for (AtomLink link : links)
-      if (link.type != null && "via".equals(link.type)) {
+      if ("via".equals(link.rel)) {
         return link.href.toString();
       }
     for (AtomLink link : links)
-      if (link.type != null && "related".equals(link.type)) {
+      if ("related".equals(link.rel)) {
         return link.href.toString();
       }
     for (AtomLink link : links)
-      if (link.type == null) {
+      if (link.rel == null) {
         return link.href.toString();
       }
     for (AtomLink link : links)
-      if (link.type != null && !"enclosure".equals(link.type) && !"self".equals(link.type)) {
+      if (link.rel != null && !"enclosure".equals(link.rel) && !"self".equals(link.rel)) {
         return link.href.toString();
       }
     return links.get(0).href.toString();
@@ -216,7 +216,7 @@ public class AtomEntry extends AtomCommonAttributes implements Item {
   public List<? extends Enclosure> getEnclosures() {
     List<Enclosure> result = new LinkedList<>();
     for (AtomLink link : links) {
-      if (link.type != null && "enclosure".equals(link.type)) {
+      if (link.rel != null && "enclosure".equals(link.rel)) {
         result.add(link);
       }
     }

--- a/earl/src/main/java/com/einmalfel/earl/AtomFeed.java
+++ b/earl/src/main/java/com/einmalfel/earl/AtomFeed.java
@@ -162,23 +162,23 @@ public class AtomFeed extends AtomCommonAttributes implements Feed {
       return null;
     }
     for (AtomLink link : links)
-      if (link.type != null && "alternate".equals(link.type)) {
+      if ("alternate".equals(link.rel)) {
         return link.href.toString();
       }
     for (AtomLink link : links)
-      if (link.type != null && "via".equals(link.type)) {
+      if ("via".equals(link.rel)) {
         return link.href.toString();
       }
     for (AtomLink link : links)
-      if (link.type != null && "related".equals(link.type)) {
+      if ("related".equals(link.rel)) {
         return link.href.toString();
       }
     for (AtomLink link : links)
-      if (link.type == null) {
+      if (link.rel == null) {
         return link.href.toString();
       }
     for (AtomLink link : links)
-      if (link.type != null && !"enclosure".equals(link.type) && !"self".equals(link.type)) {
+      if (link.rel != null && !"enclosure".equals(link.rel) && !"self".equals(link.rel)) {
         return link.href.toString();
       }
     return links.get(0).href.toString();


### PR DESCRIPTION
According to: https://tools.ietf.org/html/rfc4287#section-7.1

"alternate", "related", "self", "enclosure", and "via" are supposed to be in `rel` attribute, not in `type`. This is now fixed with this pull request.

Also, there's no need to check for `null` as the latter check will fail anyway if that was the case.
